### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "run"

--- a/README.md
+++ b/README.md
@@ -33,3 +33,5 @@ Modules:
   * Python 3.x
   * Pygame
   * Tkinter
+
+[![Run on Repl.it](https://repl.it/badge/github/Burakcoli/Pyint_Pixel-Painter)](https://repl.it/github/Burakcoli/Pyint_Pixel-Painter)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@millergaming200/PyintPixel-Painter-1).